### PR TITLE
Bug: Related Products Filter: Always Self-Matching Resolved

### DIFF
--- a/components/product-details.tsx
+++ b/components/product-details.tsx
@@ -69,10 +69,10 @@ export default function ProductDetails({ id: productId }: { id: string }) {
           search: "",
         });
 
-        const uniqueProducts = response.products.filter((product) =>
-            product.category_id == product?.category_id
+        const filtered = response.products.filter(
+          (p) => p.id !== product?.id && p.category_id === product?.category_id
         );
-        setRelatedProducts(uniqueProducts);
+        setRelatedProducts(filtered);
       } catch (err) {
         console.error("Error loading products:", err);
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix related products to only include same-category items and exclude the current product.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 307ccdd4f250df99097b2bd48002eb2646ef64a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->