### PR TITLE
fix(notifications): service-role DB access after auth; RLS + grant mi…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ app/
 
 ### Key Conventions
 - API routes use server-only secrets (never expose UPI/shipping keys to client)
+- `POST|GET /api/notifications` and `PATCH /api/notifications/[id]` verify the session, then use **`SUPABASE_SERVICE_ROLE_KEY`** to read/write rows scoped by `user_id` (avoids `GRANT`/`RLS` drift across Supabase projects)
 - `AddressFormModal` accepts `enablePincodeCheck` prop to toggle Delhivery validation
 - `lib/types/` for shared TypeScript types, `lib/utils/` for helpers, `lib/services/` for API clients
 

--- a/app/api/notifications/[id]/route.ts
+++ b/app/api/notifications/[id]/route.ts
@@ -1,22 +1,57 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { cookies } from "next/headers";
+import {
+  createServerSupabaseClient,
+  createAdminSupabaseClient,
+} from "@/lib/supabase-server";
 
-export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   try {
-    const supabase = await createServerSupabaseClient();
+    const cookieStore = await cookies();
+    const supabase = await createServerSupabaseClient(cookieStore);
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     const { id } = await params;
 
-    const { data, error } = await supabase
+    const admin = createAdminSupabaseClient();
+
+    const { data, error } = await admin
       .from("notifications")
       .update({ is_read: true })
       .eq("id", id)
+      .eq("user_id", user.id)
       .select()
-      .single();
+      .maybeSingle();
 
-    if (error) throw error;
+    if (error) {
+      console.error("Supabase notification patch:", error.code, error.message);
+      throw error;
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: "Notification not found" }, { status: 404 });
+    }
+
     return NextResponse.json(data);
   } catch (error) {
     console.error("Error updating notification:", error);
-    return NextResponse.json({ error: "Failed to update notification" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to update notification" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,38 +1,124 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { cookies } from "next/headers";
+import {
+  createServerSupabaseClient,
+  createAdminSupabaseClient,
+} from "@/lib/supabase-server";
 
+/**
+ * Auth with the user-scoped client; read/write notifications with the admin client
+ * scoped by `user_id`. Avoids `GRANT ... TO authenticated` drift across Supabase projects.
+ */
 export async function POST(req: Request) {
-    try {
-        const supabase = await createServerSupabaseClient();
-        const body = await req.json();
-        const { title, message, type } = body;
-        const { data, error } = await supabase
-            .from("notifications")
-            .insert([{ title, message, type }])
-            .select()
-            .single();
+  try {
+    const cookieStore = await cookies();
+    const supabase = await createServerSupabaseClient(cookieStore);
 
-        if (error) throw error;
-        return NextResponse.json(data);
-    } catch (error) {
-        console.error("Error creating notification:", error);
-        return NextResponse.json({ error: "Failed to create notification" }, { status: 500 });
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
     }
+
+    const body = await req.json();
+    const { title, message, type } = body;
+
+    if (
+      typeof title !== "string" ||
+      title.trim() === "" ||
+      typeof message !== "string" ||
+      message.trim() === ""
+    ) {
+      return NextResponse.json(
+        { error: "title and message are required strings" },
+        { status: 400 }
+      );
+    }
+
+    const admin = createAdminSupabaseClient();
+
+    const { data, error } = await admin
+      .from("notifications")
+      .insert([
+        {
+          user_id: user.id,
+          title: title.trim(),
+          message: message.trim(),
+          type: typeof type === "string" && type.trim() ? type.trim() : "info",
+        },
+      ])
+      .select()
+      .single();
+
+    if (error) {
+      console.error("Supabase notification insert:", error.code, error.message, error.details);
+      const dev = process.env.NODE_ENV === "development";
+      return NextResponse.json(
+        {
+          error: "Failed to create notification",
+          ...(dev && {
+            supabaseCode: error.code,
+            supabaseMessage: error.message,
+          }),
+        },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error creating notification:", error);
+    const dev = process.env.NODE_ENV === "development";
+    const msg = error instanceof Error ? error.message : String(error);
+    return NextResponse.json(
+      {
+        error: "Failed to create notification",
+        ...(dev && { hint: msg }),
+      },
+      { status: 500 }
+    );
+  }
 }
 
-
 export async function GET() {
-    try {
-        const supabase = await createServerSupabaseClient();
-        const { data, error } = await supabase
-            .from("notifications")
-            .select("*")
-            .order("created_at", { ascending: false });
+  try {
+    const cookieStore = await cookies();
+    const supabase = await createServerSupabaseClient(cookieStore);
 
-        if (error) throw error;
-        return NextResponse.json({ notifications: data });
-    } catch (error) {
-        console.error("Error fetching notifications:", error);
-        return NextResponse.json({ error: "Failed to fetch notifications" }, { status: 500 });
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ notifications: [] });
     }
+
+    const admin = createAdminSupabaseClient();
+
+    const { data, error } = await admin
+      .from("notifications")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      console.error("Supabase notification list:", error.code, error.message);
+      throw error;
+    }
+
+    return NextResponse.json({ notifications: data ?? [] });
+  } catch (error) {
+    console.error("Error fetching notifications:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch notifications" },
+      { status: 500 }
+    );
+  }
 }

--- a/lib/services/admin-order-notifications.ts
+++ b/lib/services/admin-order-notifications.ts
@@ -46,6 +46,7 @@ export async function notifyAdminsOrderPlacedFromCheckout(order: {
       title,
       message,
       type: "order_status",
+      is_read: false,
       read: false,
       meta,
     });

--- a/lib/utils/notify.ts
+++ b/lib/utils/notify.ts
@@ -3,6 +3,7 @@ export async function sendNotification(title: string, message: string, type = "i
         const response = await fetch("/api/notifications", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
+            credentials: "same-origin",
             body: JSON.stringify({ title, message, type }),
         });
 

--- a/supabase/migrations/20260402120000_notifications_authenticated_rls.sql
+++ b/supabase/migrations/20260402120000_notifications_authenticated_rls.sql
@@ -1,0 +1,21 @@
+-- Storefront POST/GET /api/notifications uses anon key + user JWT (role: authenticated).
+-- Previously only service_role had an RLS policy, so inserts/selects always failed.
+
+CREATE POLICY "notifications_select_own"
+  ON public.notifications
+  FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "notifications_insert_own"
+  ON public.notifications
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "notifications_update_own"
+  ON public.notifications
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/20260402130000_notifications_grant_authenticated.sql
+++ b/supabase/migrations/20260402130000_notifications_grant_authenticated.sql
@@ -1,0 +1,2 @@
+-- Table privileges were only postgres + service_role; RLS alone is not enough.
+GRANT SELECT, INSERT, UPDATE ON public.notifications TO authenticated;


### PR DESCRIPTION
…grations

- POST/GET/PATCH /api/notifications use admin client scoped by user_id (fixes 42501 on projects without authenticated GRANT)
- notify: credentials same-origin; dev JSON hints on insert failure
- admin-order-notifications: is_read column
- Migrations: authenticated RLS policies + GRANT for parity across envs
- CLAUDE.md: document notifications API + service role

Made-with: Cursor