### PR TITLE
fix(impersonation): stop minting admin JWT while acting_as cookie is set

### DIFF
--- a/components/supabase-auth-provider.tsx
+++ b/components/supabase-auth-provider.tsx
@@ -10,6 +10,11 @@ import {
 } from "react";
 import { createClient } from "@/lib/supabase";
 import type { User, Session } from "@supabase/supabase-js";
+import {
+  requestAuthToken,
+  resolveAuthToken,
+  type ResolveAuthTokenResult,
+} from "@/lib/auth/generate-jwt-token";
 
 interface UserProfile {
   id: string;
@@ -80,32 +85,46 @@ export function SupabaseAuthProvider({
   const inflightRef = useRef<Map<string, Promise<any>>>(new Map());
   const isMountedRef = useRef(true);
 
-  // Helper function to generate JWT token (deduplicated)
-  const generateJwtToken = useCallback(async (userId: string, userEmail?: string) => {
-    const key = `token:${userId}`;
-    const existing = inflightRef.current.get(key);
-    if (existing) return existing;
+  // Refs mirroring state that the token-mint flow needs to read without
+  // re-subscribing. `impersonationActiveRef` lets `mintAuthToken` gate the
+  // HTTP call on the latest impersonation state even when invoked from a
+  // memoised callback; `jwtTokenRef` exposes the previously-minted token so
+  // `resolveAuthToken` can preserve it across impersonation and transient
+  // network errors instead of silently wiping a still-valid JWT.
+  const impersonationActiveRef = useRef(false);
+  const jwtTokenRef = useRef<string | null>(null);
 
-    const promise = (async () => {
-      try {
-        const response = await fetch("/api/auth/generate-token", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ userId, userEmail }),
-        });
-        if (response.ok) {
-          const data = await response.json();
-          return data.token;
-        }
-      } catch (error) {
-        console.error("Error generating JWT token:", error);
-      }
-      return null;
-    })().finally(() => { inflightRef.current.delete(key); });
+  // Mint a JWT for the given session user, gated on impersonation state.
+  // Returns the resolved `{ token, action }` so callers can decide whether
+  // to commit the token to state (unchanged values short-circuit the
+  // downstream render). Deduplicated per userId + impersonation state so
+  // concurrent callers don't double-post to `/api/auth/generate-token`.
+  const mintAuthToken = useCallback(
+    async (
+      userId: string,
+      userEmail: string | undefined
+    ): Promise<ResolveAuthTokenResult> => {
+      const key = `token:${userId}:${impersonationActiveRef.current ? "imp" : "normal"}`;
+      const existing = inflightRef.current.get(key) as
+        | Promise<ResolveAuthTokenResult>
+        | undefined;
+      if (existing) return existing;
 
-    inflightRef.current.set(key, promise);
-    return promise;
-  }, []);
+      const promise = resolveAuthToken({
+        userId,
+        userEmail,
+        impersonationActive: impersonationActiveRef.current,
+        previousToken: jwtTokenRef.current,
+        request: requestAuthToken,
+      }).finally(() => {
+        inflightRef.current.delete(key);
+      });
+
+      inflightRef.current.set(key, promise);
+      return promise;
+    },
+    []
+  );
 
   // Helper function to create user profile if it doesn't exist (deduplicated)
   const ensureUserProfile = useCallback(async (userId: string) => {
@@ -136,7 +155,13 @@ export function SupabaseAuthProvider({
     return promise;
   }, []);
 
-  // Helper function to update user profile
+  // Helper function to update user profile.
+  //
+  // Token lifecycle is deliberately NOT handled here — it lives in a
+  // dedicated effect below that waits for impersonation state to resolve
+  // before minting. Doing it here would race the impersonation probe and
+  // fire `/api/auth/generate-token` with the `acting_as` cookie still in
+  // flight, which the server (correctly) refuses with 403.
   const updateUserProfile = useCallback(async (currentSession: Session | null) => {
     if (currentSession?.user) {
       try {
@@ -147,28 +172,15 @@ export function SupabaseAuthProvider({
         // New users fall back to 'customer' (correct); role appears in JWT on next refresh.
         const role = (currentSession.user.app_metadata?.role as UserProfile['role']) ?? 'customer';
         setUserProfile({ id: currentSession.user.id, role });
-
-        // Generate JWT token for API authentication
-        const token = await generateJwtToken(
-          currentSession.user.id,
-          currentSession.user.email
-        );
-        setJwtToken(token);
       } catch (error) {
         console.error("Error updating user profile:", error);
         // Set default customer profile on error
         setUserProfile({ id: currentSession.user.id, role: "customer" });
-        const token = await generateJwtToken(
-          currentSession.user.id,
-          currentSession.user.email
-        );
-        setJwtToken(token);
       }
     } else {
       setUserProfile(null);
-      setJwtToken(null);
     }
-  }, [generateJwtToken, ensureUserProfile]);
+  }, [ensureUserProfile]);
 
   // Fetch /api/admin/impersonation/state with request dedup.
   // Safe to call often; the endpoint is explicitly designed to be poll-friendly.
@@ -340,6 +352,55 @@ export function SupabaseAuthProvider({
     document.addEventListener("visibilitychange", handler);
     return () => document.removeEventListener("visibilitychange", handler);
   }, [refreshImpersonation]);
+
+  // Keep refs consumed by `mintAuthToken` in sync with the latest state.
+  useEffect(() => {
+    impersonationActiveRef.current = impersonation.active;
+  }, [impersonation.active]);
+
+  useEffect(() => {
+    jwtTokenRef.current = jwtToken;
+  }, [jwtToken]);
+
+  // Session JWT lifecycle.
+  //
+  // The token MUST only be minted when impersonation is known to be
+  // inactive — `/api/auth/generate-token` is an identity-mutation endpoint
+  // that `blockIfImpersonating` refuses whenever the `acting_as` cookie is
+  // present (it would be a privilege-escalation surface otherwise). So we
+  // wait for `impersonationReady` before the first mint and skip the HTTP
+  // call entirely whenever `impersonation.active` is true.
+  //
+  // When impersonation ends (active: true → false) this effect re-runs and
+  // mints a fresh token automatically.
+  //
+  // When the user signs out (no session), we clear the token synchronously
+  // without hitting the network.
+  useEffect(() => {
+    if (!session?.user) {
+      setJwtToken(null);
+      return;
+    }
+    if (!impersonationReady) return;
+    if (impersonation.active) return;
+
+    let cancelled = false;
+    const { id, email } = session.user;
+    (async () => {
+      const { token } = await mintAuthToken(id, email);
+      if (cancelled || !isMountedRef.current) return;
+      setJwtToken((prev) => (prev === token ? prev : token));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    session?.user?.id,
+    session?.user?.email,
+    impersonationReady,
+    impersonation.active,
+    mintAuthToken,
+  ]);
 
   const signIn = async (email: string, password: string) => {
     const { error } = await supabase.auth.signInWithPassword({

--- a/lib/auth/generate-jwt-token.test.ts
+++ b/lib/auth/generate-jwt-token.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  requestAuthToken,
+  resolveAuthToken,
+  type GenerateJwtResult,
+} from './generate-jwt-token';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('requestAuthToken', () => {
+  it('returns { ok: true, token } on 200 with a token payload', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ token: 'jwt-abc', success: true }, 200));
+    const result = await requestAuthToken('u1', 'u1@example.com', fetchMock);
+    expect(result).toEqual({ ok: true, token: 'jwt-abc' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/generate-token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+
+  it('returns { ok: false, reason: "impersonating" } on 403 "Forbidden while impersonating"', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        jsonResponse({ error: 'Forbidden while impersonating' }, 403)
+      );
+    const result = await requestAuthToken('u1', 'u1@example.com', fetchMock);
+    expect(result).toEqual({ ok: false, reason: 'impersonating' });
+  });
+
+  it('returns { ok: false, reason: "http_error" } on other non-OK status codes', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
+    const result = await requestAuthToken('u1', undefined, fetchMock);
+    expect(result).toEqual({ ok: false, reason: 'http_error' });
+  });
+
+  it('returns { ok: false, reason: "http_error" } when 200 body is missing a token', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ success: true }, 200));
+    const result = await requestAuthToken('u1', undefined, fetchMock);
+    expect(result).toEqual({ ok: false, reason: 'http_error' });
+  });
+
+  it('returns { ok: false, reason: "network_error" } when fetch throws', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('offline'));
+    const result = await requestAuthToken('u1', undefined, fetchMock);
+    expect(result).toEqual({ ok: false, reason: 'network_error' });
+  });
+});
+
+describe('resolveAuthToken', () => {
+  const baseArgs = {
+    userId: 'u1',
+    userEmail: 'u1@example.com',
+    previousToken: 'prev-token',
+  } as const;
+
+  it('skips the HTTP mint when impersonation is active and preserves the previous token', async () => {
+    const request = vi.fn<
+      (userId: string, userEmail: string | undefined) => Promise<GenerateJwtResult>
+    >();
+    const result = await resolveAuthToken({
+      ...baseArgs,
+      impersonationActive: true,
+      request,
+    });
+    expect(request).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      token: 'prev-token',
+      action: 'skipped_impersonating',
+    });
+  });
+
+  it('mints a fresh token when impersonation is inactive and server returns 200', async () => {
+    const request = vi
+      .fn<
+        (userId: string, userEmail: string | undefined) => Promise<GenerateJwtResult>
+      >()
+      .mockResolvedValue({ ok: true, token: 'fresh' });
+    const result = await resolveAuthToken({
+      ...baseArgs,
+      impersonationActive: false,
+      request,
+    });
+    expect(request).toHaveBeenCalledWith('u1', 'u1@example.com');
+    expect(result).toEqual({ token: 'fresh', action: 'minted' });
+  });
+
+  it('preserves the previous token (does NOT null it out) if the server races and returns 403', async () => {
+    const request = vi
+      .fn<
+        (userId: string, userEmail: string | undefined) => Promise<GenerateJwtResult>
+      >()
+      .mockResolvedValue({ ok: false, reason: 'impersonating' });
+    const result = await resolveAuthToken({
+      ...baseArgs,
+      impersonationActive: false,
+      request,
+    });
+    expect(result).toEqual({
+      token: 'prev-token',
+      action: 'preserved_on_server_block',
+    });
+  });
+
+  it('clears the token on http_error so broken tokens are not reused', async () => {
+    const request = vi
+      .fn<
+        (userId: string, userEmail: string | undefined) => Promise<GenerateJwtResult>
+      >()
+      .mockResolvedValue({ ok: false, reason: 'http_error' });
+    const result = await resolveAuthToken({
+      ...baseArgs,
+      impersonationActive: false,
+      request,
+    });
+    expect(result).toEqual({ token: null, action: 'failed' });
+  });
+
+  it('preserves the previous token on a transient network_error', async () => {
+    const request = vi
+      .fn<
+        (userId: string, userEmail: string | undefined) => Promise<GenerateJwtResult>
+      >()
+      .mockResolvedValue({ ok: false, reason: 'network_error' });
+    const result = await resolveAuthToken({
+      ...baseArgs,
+      impersonationActive: false,
+      request,
+    });
+    expect(result).toEqual({
+      token: 'prev-token',
+      action: 'preserved_on_network_error',
+    });
+  });
+});

--- a/lib/auth/generate-jwt-token.ts
+++ b/lib/auth/generate-jwt-token.ts
@@ -1,0 +1,127 @@
+/**
+ * Client-side helpers for minting the session user's JWT against
+ * `POST /api/auth/generate-token`.
+ *
+ * The server route is fronted by `blockIfImpersonating` — whenever the
+ * admin's `acting_as` cookie is present, the endpoint refuses with 403
+ * "Forbidden while impersonating" regardless of which userId is in the
+ * body. That is intentional: `/api/auth/generate-token` accepts an
+ * arbitrary `userId` in the body without cross-checking the session, so
+ * during impersonation it is a live privilege-escalation surface.
+ *
+ * The client therefore:
+ *   1. MUST NOT call the endpoint while impersonation is active
+ *      (avoids noisy 403s and prevents clobbering the admin's token).
+ *   2. MUST treat a 403 returned from the endpoint as a benign signal
+ *      (never a hard error) — it only means the guard caught a race
+ *      where impersonation state flipped mid-flight.
+ *   3. MUST preserve any previously-minted session JWT in both cases;
+ *      overwriting it with null would silently break anything that
+ *      relies on `jwtToken` for API auth.
+ *
+ * Both `requestAuthToken` and `resolveAuthToken` are pure functions
+ * (no state, no React) so they can be exhaustively unit-tested without
+ * a DOM or RTL setup.
+ */
+
+export type GenerateJwtReason =
+  | 'impersonating'
+  | 'http_error'
+  | 'network_error';
+
+export type GenerateJwtResult =
+  | { ok: true; token: string }
+  | { ok: false; reason: GenerateJwtReason };
+
+export type ResolveAuthTokenAction =
+  | 'minted'
+  | 'skipped_impersonating'
+  | 'preserved_on_server_block'
+  | 'preserved_on_network_error'
+  | 'failed';
+
+export interface ResolveAuthTokenResult {
+  token: string | null;
+  action: ResolveAuthTokenAction;
+}
+
+export interface ResolveAuthTokenArgs {
+  userId: string;
+  userEmail: string | undefined;
+  impersonationActive: boolean;
+  previousToken: string | null;
+  request: (
+    userId: string,
+    userEmail: string | undefined
+  ) => Promise<GenerateJwtResult>;
+}
+
+const ENDPOINT = '/api/auth/generate-token';
+
+export async function requestAuthToken(
+  userId: string,
+  userEmail: string | undefined,
+  fetchImpl: typeof fetch = fetch
+): Promise<GenerateJwtResult> {
+  let response: Response;
+  try {
+    response = await fetchImpl(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, userEmail }),
+    });
+  } catch {
+    return { ok: false, reason: 'network_error' };
+  }
+
+  if (response.ok) {
+    try {
+      const data = (await response.json()) as { token?: unknown };
+      if (typeof data?.token === 'string' && data.token.length > 0) {
+        return { ok: true, token: data.token };
+      }
+      return { ok: false, reason: 'http_error' };
+    } catch {
+      return { ok: false, reason: 'http_error' };
+    }
+  }
+
+  if (response.status === 403) {
+    return { ok: false, reason: 'impersonating' };
+  }
+
+  return { ok: false, reason: 'http_error' };
+}
+
+export async function resolveAuthToken(
+  args: ResolveAuthTokenArgs
+): Promise<ResolveAuthTokenResult> {
+  if (args.impersonationActive) {
+    return {
+      token: args.previousToken,
+      action: 'skipped_impersonating',
+    };
+  }
+
+  const result = await args.request(args.userId, args.userEmail);
+
+  if (result.ok) {
+    return { token: result.token, action: 'minted' };
+  }
+
+  if (result.reason === 'impersonating') {
+    return {
+      token: args.previousToken,
+      action: 'preserved_on_server_block',
+    };
+  }
+
+  if (result.reason === 'network_error') {
+    return {
+      token: args.previousToken,
+      action: 'preserved_on_network_error',
+    };
+  }
+
+  return { token: null, action: 'failed' };
+}

--- a/tests/admin-impersonation.spec.ts
+++ b/tests/admin-impersonation.spec.ts
@@ -67,6 +67,23 @@ test("admin impersonation: create user and place order on behalf", async ({
   });
   page.on("pageerror", (err) => errors.push(`PAGE: ${err.message}`));
 
+  // Track any 4xx/5xx responses from `/api/auth/generate-token`. The client
+  // MUST NOT call this endpoint while the admin is impersonating — the
+  // server route is fronted by `blockIfImpersonating` (identity-mutation
+  // surface) and will reject with 403 "Forbidden while impersonating"
+  // whenever the `acting_as` cookie is present. This assertion guards
+  // against a regression where the auth provider re-introduces the
+  // unconditional mint on every auth state change.
+  const generateTokenFailures: string[] = [];
+  page.on("response", (resp) => {
+    const url = resp.url();
+    if (!url.includes("/api/auth/generate-token")) return;
+    const status = resp.status();
+    if (status >= 400) {
+      generateTokenFailures.push(`${resp.request().method()} ${status} ${url}`);
+    }
+  });
+
   const targetEmailFirst = uniqueTargetEmail();
   const targetPhone = randomIndianMobile();
   const targetName = "Impersonation Test User";
@@ -442,6 +459,23 @@ test("admin impersonation: create user and place order on behalf", async ({
   expect(
     realErrors,
     `Browser/page errors detected during impersonation flow:\n${realErrors.join("\n")}`
+  ).toHaveLength(0);
+
+  // Regression guard: /api/auth/generate-token must never 4xx/5xx during a
+  // full impersonation lifecycle. A 403 here means the auth provider tried
+  // to mint the admin's JWT while the `acting_as` cookie was set — the
+  // symptom that triggered the client-side gating in
+  // components/supabase-auth-provider.tsx (token mint deferred until
+  // impersonation state is resolved AND inactive).
+  if (generateTokenFailures.length > 0) {
+    console.log("❌ /api/auth/generate-token failures:");
+    generateTokenFailures.forEach((e) => console.log("  ", e));
+  } else {
+    console.log("✅ No /api/auth/generate-token failures");
+  }
+  expect(
+    generateTokenFailures,
+    `/api/auth/generate-token returned an error status during the impersonation flow — the client must not call this endpoint while impersonation is active:\n${generateTokenFailures.join("\n")}`
   ).toHaveLength(0);
 
   // Cleanup placeholder — see top-of-file comment. The test deliberately


### PR DESCRIPTION
## Summary

`POST /api/auth/generate-token` is fronted by `blockIfImpersonating` and refuses identity-mutation calls whenever the `acting_as` cookie is present (the route accepts an arbitrary `userId` in the body without cross-checking the session, so during impersonation it is a live privilege-escalation surface — the 403 is load-bearing security).

The client, however, re-minted the session JWT on **every** Supabase `onAuthStateChange` event (token refresh, tab focus, remount). While the admin was impersonating, every one of those events produced:

```
POST /api/auth/generate-token → 403 Forbidden while impersonating
{ userId: "<admin-id>", userEmail: "admin@cozyberries.in" }
```

…and the client silently nulled `jwtToken`, breaking anything downstream of `useAuthenticatedFetch` mid-session.

## Changes

- **`lib/auth/generate-jwt-token.ts`** (new) — two pure, fully-tested helpers:
  - `requestAuthToken` maps a 403 to `{ ok: false, reason: 'impersonating' }` instead of a generic failure.
  - `resolveAuthToken` gates on `impersonationActive`, preserves the previous token on server blocks and transient network errors, and only nulls it on real HTTP errors.
- **`components/supabase-auth-provider.tsx`** — token lifecycle moved out of `updateUserProfile` into a dedicated effect that:
  - waits for `impersonationReady` before the first mint,
  - skips the HTTP call entirely while `impersonation.active` is `true`,
  - auto re-mints when impersonation ends (active: true → false),
  - uses refs (`impersonationActiveRef`, `jwtTokenRef`) so `mintAuthToken` reads the latest state without re-subscribing,
  - short-circuits `setJwtToken` on value equality to avoid redundant renders.
- **`lib/auth/generate-jwt-token.test.ts`** (new) — 10 unit tests covering every branch of both helpers.
- **`tests/admin-impersonation.spec.ts`** — regression guard: any 4xx/5xx from `/api/auth/generate-token` during the full impersonation lifecycle fails the E2E.

Server-side (`blockIfImpersonating`, `/api/auth/generate-token`) is intentionally untouched — the guard is correct.

## Test plan

- [x] `npm run test:unit` → 217/217 passed (30 files)
- [x] `tsc --noEmit` — no new errors on touched files
- [x] Lints clean on touched files
- [ ] `npm run test:admin-impersonation` (Playwright) — reviewer to run with `TEST_ADMIN_EMAIL` / `TEST_ADMIN_PASSWORD` set; confirm new `/api/auth/generate-token` assertion passes
- [ ] Manual smoke on preview:
  - [ ] Admin signs in → JWT present, no 403 in Network
  - [ ] Admin starts impersonation → no new `/api/auth/generate-token` requests on tab focus / Supabase token refresh
  - [ ] Admin exits impersonation → JWT automatically re-minted (Network shows one 200)
  - [ ] Reload page mid-impersonation → no 403 after impersonation state resolves

## Notes for reviewers

- The client keeps the Supabase cookie-based auth for server routes; `jwtToken` is only needed for the `useAuthenticatedFetch` `Authorization: Bearer` header. Preserving it across impersonation avoids silent auth gaps for admins who briefly hop into a target session.
- `mintAuthToken` deduplicates per `userId + impersonationActive` so concurrent callers (e.g. parallel hooks firing on the same auth event) don't double-post.