### PR TITLE
feat(analytics): integrate Meta Pixel + Conversions API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ VERIFYNOW_PHONE_PLACEHOLDER_EMAIL_DOMAIN=phone.cozyburry.local
 
 # Frontend URL (used in layout and for phone OTP callback). e.g. https://cozyberries.in or http://localhost:3000
 NEXT_PUBLIC_FRONTEND_URL=
+
+# Meta Pixel + Conversions API
+# Pixel ID is public (safe to expose to browser)
+NEXT_PUBLIC_META_PIXEL_ID=your-pixel-id-here
+# Server-only token: Facebook Business Manager → Events Manager → your pixel → Settings → "Generate Access Token"
+FACEBOOK_CONVERSIONS_API_TOKEN=REPLACE_WITH_YOUR_TOKEN_FROM_EVENTS_MANAGER

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ logs
 .env.development.local
 .env.test.local
 .env.production.local
+.worktrees/

--- a/app/api/analytics/events/route.ts
+++ b/app/api/analytics/events/route.ts
@@ -25,7 +25,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const { eventName, eventId, eventSourceUrl, customData } = body;
-  if (!eventName || !eventId || !eventSourceUrl) {
+  const VALID_EVENTS = ['AddToCart', 'InitiateCheckout'] as const;
+  if (!eventName || !VALID_EVENTS.includes(eventName) || !eventId || !eventSourceUrl) {
     return NextResponse.json({ ok: false, error: 'Missing required fields' }, { status: 400 });
   }
 

--- a/app/api/analytics/events/route.ts
+++ b/app/api/analytics/events/route.ts
@@ -1,0 +1,70 @@
+// app/api/analytics/events/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { sendConversionsEvent } from '@/lib/analytics/conversions-api';
+
+interface EventBody {
+  eventName: 'AddToCart' | 'InitiateCheckout';
+  eventId: string;
+  eventSourceUrl: string;
+  customData?: {
+    value?: number;
+    currency?: string;
+    content_ids?: string[];
+    num_items?: number;
+  };
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: EventBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { eventName, eventId, eventSourceUrl, customData } = body;
+  if (!eventName || !eventId || !eventSourceUrl) {
+    return NextResponse.json({ ok: false, error: 'Missing required fields' }, { status: 400 });
+  }
+
+  // Get user PII for hashing — optional, events fire even without auth
+  let userEmail: string | undefined;
+  let userPhone: string | undefined;
+  try {
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { cookies: { getAll: () => cookieStore.getAll() } }
+    );
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      userEmail = user.email ?? undefined;
+      userPhone = user.phone ?? undefined;
+    }
+  } catch {
+    // Proceed without user data
+  }
+
+  const clientIp =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    undefined;
+  const userAgent = request.headers.get('user-agent') ?? undefined;
+
+  // Fire-and-forget — never let analytics failure affect the response
+  sendConversionsEvent({
+    eventName,
+    eventId,
+    eventSourceUrl,
+    userEmail,
+    userPhone,
+    clientIp,
+    userAgent,
+    customData: { currency: 'INR', ...customData },
+  }).catch((err) => console.error('[Meta CAPI route] Unhandled error:', err));
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/payments/confirm/route.ts
+++ b/app/api/payments/confirm/route.ts
@@ -380,7 +380,7 @@ async function handleSessionConfirm(ctx: ConfirmContext, sessionId: string) {
   sendConversionsEvent({
     eventName: 'Purchase',
     eventId: pixelEventId,
-    eventSourceUrl: `${request.headers.get('origin') ?? ''}/payment/${order.id}`,
+    eventSourceUrl: `${request.headers.get('origin') ?? process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_FRONTEND_URL ?? ''}/payment/${order.id}`,
     userEmail: sessionUser.email ?? undefined,
     userPhone: sessionUser.phone ?? undefined,
     clientIp: sessionClientIp ?? undefined,
@@ -525,7 +525,7 @@ async function handleOrderConfirm(ctx: ConfirmContext, orderId: string) {
   sendConversionsEvent({
     eventName: 'Purchase',
     eventId: pixelEventId,
-    eventSourceUrl: `${request.headers.get('origin') ?? ''}/payment/${orderId}`,
+    eventSourceUrl: `${request.headers.get('origin') ?? process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_FRONTEND_URL ?? ''}/payment/${orderId}`,
     userEmail: sessionUser.email ?? undefined,
     userPhone: sessionUser.phone ?? undefined,
     clientIp: orderClientIp ?? undefined,
@@ -533,7 +533,7 @@ async function handleOrderConfirm(ctx: ConfirmContext, orderId: string) {
     customData: {
       value: order.total_amount,
       currency: order.currency ?? 'INR',
-      content_ids: [orderId],
+      content_ids: [],
       content_type: 'product',
       order_id: orderId,
     },

--- a/app/api/payments/confirm/route.ts
+++ b/app/api/payments/confirm/route.ts
@@ -12,6 +12,7 @@ import {
   extractRequestMetadata,
   logImpersonationEvent,
 } from "@/lib/services/impersonation-audit";
+import { sendConversionsEvent } from "@/lib/analytics/conversions-api";
 
 // Schema for validating cart items
 const OrderItemSchema = z.object({
@@ -144,7 +145,7 @@ async function rollbackOrder(
 // ─── New flow: session-based confirmation ─────────────────────────────────────
 
 async function handleSessionConfirm(ctx: ConfirmContext, sessionId: string) {
-  const { client, userId, request } = ctx;
+  const { client, userId, sessionUser, request } = ctx;
 
   // 1. Load session and verify ownership + status
   const { data: session, error: sessionError } = await client
@@ -370,17 +371,41 @@ async function handleSessionConfirm(ctx: ConfirmContext, sessionId: string) {
     items: items.map((i) => ({ name: i.name, quantity: i.quantity, size: (i as any).size ?? null })),
   });
 
+  // Fire Purchase server event (fire-and-forget)
+  const pixelEventId = crypto.randomUUID();
+  const sessionItemIds = Array.isArray(session.items)
+    ? (session.items as Array<{ id: string }>).map((i) => i.id).filter(Boolean)
+    : [];
+  const { ip: sessionClientIp, user_agent: sessionUserAgent } = extractRequestMetadata(request);
+  sendConversionsEvent({
+    eventName: 'Purchase',
+    eventId: pixelEventId,
+    eventSourceUrl: `${request.headers.get('origin') ?? ''}/payment/${order.id}`,
+    userEmail: sessionUser.email ?? undefined,
+    userPhone: sessionUser.phone ?? undefined,
+    clientIp: sessionClientIp ?? undefined,
+    userAgent: sessionUserAgent ?? undefined,
+    customData: {
+      value: session.total_amount,
+      currency: session.currency ?? 'INR',
+      content_ids: sessionItemIds,
+      content_type: 'product',
+      order_id: order.id,
+    },
+  }).catch((err) => console.error('[Meta CAPI] Purchase event failed:', err));
+
   return NextResponse.json({
     success: true,
     order_id: order.id,
     order_number: order.order_number,
+    pixel_event_id: pixelEventId,
   });
 }
 
 // ─── Legacy flow: order-based confirmation ────────────────────────────────────
 
 async function handleOrderConfirm(ctx: ConfirmContext, orderId: string) {
-  const { client, userId } = ctx;
+  const { client, userId, sessionUser, request } = ctx;
 
   // Fetch order and verify ownership (already scoped to the effective user)
   const { data: order, error: orderError } = await client
@@ -494,5 +519,29 @@ async function handleOrderConfirm(ctx: ConfirmContext, orderId: string) {
     phone: order.customer_phone ?? null,
   });
 
-  return NextResponse.json({ success: true });
+  // Fire Purchase server event (fire-and-forget)
+  const pixelEventId = crypto.randomUUID();
+  const { ip: orderClientIp, user_agent: orderUserAgent } = extractRequestMetadata(request);
+  sendConversionsEvent({
+    eventName: 'Purchase',
+    eventId: pixelEventId,
+    eventSourceUrl: `${request.headers.get('origin') ?? ''}/payment/${orderId}`,
+    userEmail: sessionUser.email ?? undefined,
+    userPhone: sessionUser.phone ?? undefined,
+    clientIp: orderClientIp ?? undefined,
+    userAgent: orderUserAgent ?? undefined,
+    customData: {
+      value: order.total_amount,
+      currency: order.currency ?? 'INR',
+      content_ids: [orderId],
+      content_type: 'product',
+      order_id: orderId,
+    },
+  }).catch((err) => console.error('[Meta CAPI] Purchase event failed (legacy):', err));
+
+  return NextResponse.json({
+    success: true,
+    order_id: orderId,
+    pixel_event_id: pixelEventId,
+  });
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import PwaUpdateHandler from "@/components/PwaUpdateHandlerClient";
 import { Toaster } from "sonner";
 import { RatingProvider } from "@/components/rating-context";
 import { QueryProvider } from "@/components/query-provider";
+import MetaPixelScript from "@/components/MetaPixelScript";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -99,6 +100,7 @@ export default function RootLayout({
       </head>
       {/* suppressHydrationWarning on body helps when a browser extension (e.g. Cursor) injects data-cursor-ref into the DOM after server render */}
       <body className={inter.className} suppressHydrationWarning>
+        <MetaPixelScript />
         <QueryProvider>
           <SupabaseAuthProvider>
             <DataPreloader>

--- a/app/payment/[orderId]/page.tsx
+++ b/app/payment/[orderId]/page.tsx
@@ -20,6 +20,7 @@ import type { Order } from "@/lib/types/order";
 import { toast } from "sonner";
 import { sendNotification } from "@/lib/utils/notify";
 import { sendActivity } from "@/lib/utils/activities";
+import { trackPurchase } from "@/lib/analytics/meta-pixel";
 
 interface UpiLinks {
   phonepe: string;
@@ -111,6 +112,20 @@ export default function PaymentPage() {
       if (!res.ok) {
         const data = await res.json();
         throw new Error(data.error || "Failed to confirm payment");
+      }
+
+      const data = await res.json();
+
+      // Meta Pixel — Purchase browser event (deduplicates with server event via pixel_event_id)
+      if (data.pixel_event_id && order) {
+        trackPurchase(
+          {
+            orderId: data.order_id ?? orderId,
+            total: order.total_amount,
+            itemIds: [],
+          },
+          data.pixel_event_id
+        );
       }
 
       toast.success("Order Placed Successfully!");

--- a/app/products/ProductsClient.tsx
+++ b/app/products/ProductsClient.tsx
@@ -19,6 +19,7 @@ import { getProducts, type Product } from "@/lib/services/api";
 import { useCategoryOptions, useSizeOptions, useGenderOptions } from "@/hooks/useApiQueries";
 import { Loader, Search, X, RotateCcw, LayoutGrid, LayoutList } from "lucide-react";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { trackSearch } from '@/lib/analytics/meta-pixel';
 
 const PAGE_SIZE = 12;
 // Max pages to re-fetch for scroll restore (prevents 4+ sequential API calls on back-nav)
@@ -424,6 +425,13 @@ export default function ProductsClient() {
       window.scrollTo({ top: 0, behavior: "auto" });
     }
   }, [isLoading, allProducts.length, hasMoreProducts, isLoadingMore, loadMoreProducts]);
+
+  // Meta Pixel — Search
+  useEffect(() => {
+    if (currentSearch.trim()) {
+      trackSearch({ query: currentSearch });
+    }
+  }, [currentSearch]);
 
   // Submit search — updates URL param which triggers server-side fetch
   const handleSearchSubmit = (e: React.FormEvent) => {

--- a/components/MetaPixelScript.tsx
+++ b/components/MetaPixelScript.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import { trackPageView } from '@/lib/analytics/meta-pixel';
+
+export default function MetaPixelScript() {
+  const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+  const pathname = usePathname();
+
+  // Fire PageView on every SPA navigation (initial load is handled by the inline script)
+  useEffect(() => {
+    trackPageView();
+  }, [pathname]);
+
+  if (!pixelId) return null;
+
+  const initScript = `
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window,document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init','${pixelId}');
+    fbq('track','PageView');
+  `.trim();
+
+  return (
+    <>
+      <Script
+        id="meta-pixel"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: initScript }}
+      />
+      <noscript>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          height="1"
+          width="1"
+          style={{ display: 'none' }}
+          src={`https://www.facebook.com/tr?id=${pixelId}&ev=PageView&noscript=1`}
+          alt=""
+        />
+      </noscript>
+    </>
+  );
+}

--- a/components/MetaPixelScript.tsx
+++ b/components/MetaPixelScript.tsx
@@ -2,19 +2,24 @@
 
 import Script from 'next/script';
 import { usePathname } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { trackPageView } from '@/lib/analytics/meta-pixel';
 
 export default function MetaPixelScript() {
   const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
   const pathname = usePathname();
+  const isFirstRender = useRef(true);
 
-  // Fire PageView on every SPA navigation (initial load is handled by the inline script)
+  // Fire PageView on SPA navigations — skip first mount (inline script handles initial load)
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     trackPageView();
   }, [pathname]);
 
-  if (!pixelId) return null;
+  if (!pixelId || !/^\d+$/.test(pixelId)) return null;
 
   const initScript = `
     !function(f,b,e,v,n,t,s)

--- a/components/product-interactions.tsx
+++ b/components/product-interactions.tsx
@@ -26,6 +26,7 @@ import { getDiscountedPrice } from '@/lib/utils/discount'
 import { sendNotification } from "@/lib/utils/notify";
 import { sendActivity } from "@/lib/utils/activities";
 import { FREE_DELIVERY_THRESHOLD } from "@/lib/constants";
+import { trackViewContent } from "@/lib/analytics/meta-pixel";
 
 interface ReviewItem {
   userName: string;
@@ -150,6 +151,12 @@ export default function ProductInteractions({ product, initialSize: initialSizeP
       toast.error("Something went wrong. Please try again.");
     }
   };
+
+  // Meta Pixel — ViewContent
+  useEffect(() => {
+    trackViewContent({ id: product.id, name: product.name, price: product.price });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [product.id]);
 
   // Scroll to top on product change (e.g. clicking a related product)
   useEffect(() => {

--- a/lib/analytics/conversions-api.ts
+++ b/lib/analytics/conversions-api.ts
@@ -1,0 +1,72 @@
+// lib/analytics/conversions-api.ts
+import { createHash } from 'crypto';
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value.trim().toLowerCase()).digest('hex');
+}
+
+function hashPhone(raw: string): string {
+  const digits = raw.replace(/\D/g, '');
+  return createHash('sha256').update(digits).digest('hex');
+}
+
+interface ConversionsEventParams {
+  eventName: string;
+  eventId: string;
+  eventSourceUrl: string;
+  userEmail?: string;
+  userPhone?: string;
+  clientIp?: string;
+  userAgent?: string;
+  customData?: Record<string, unknown>;
+}
+
+export async function sendConversionsEvent(params: ConversionsEventParams): Promise<void> {
+  const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+  const token = process.env.FACEBOOK_CONVERSIONS_API_TOKEN;
+
+  if (!pixelId || !token) {
+    console.warn('[Meta CAPI] Missing NEXT_PUBLIC_META_PIXEL_ID or FACEBOOK_CONVERSIONS_API_TOKEN — skipping');
+    return;
+  }
+
+  const userData: Record<string, unknown> = {};
+  if (params.userEmail) userData.em = [sha256(params.userEmail)];
+  if (params.userPhone) {
+    const hashed = hashPhone(params.userPhone);
+    if (hashed) userData.ph = [hashed];
+  }
+  if (params.clientIp) userData.client_ip_address = params.clientIp;
+  if (params.userAgent) userData.client_user_agent = params.userAgent;
+
+  const payload = {
+    data: [
+      {
+        event_name: params.eventName,
+        event_time: Math.floor(Date.now() / 1000),
+        event_id: params.eventId,
+        event_source_url: params.eventSourceUrl,
+        action_source: 'website',
+        user_data: userData,
+        custom_data: { currency: 'INR', ...params.customData },
+      },
+    ],
+  };
+
+  try {
+    const res = await fetch(
+      `https://graph.facebook.com/v19.0/${pixelId}/events?access_token=${token}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      console.error('[Meta CAPI] API error:', res.status, body);
+    }
+  } catch (err) {
+    console.error('[Meta CAPI] Network error:', err);
+  }
+}

--- a/lib/analytics/conversions-api.ts
+++ b/lib/analytics/conversions-api.ts
@@ -33,8 +33,7 @@ export async function sendConversionsEvent(params: ConversionsEventParams): Prom
   const userData: Record<string, unknown> = {};
   if (params.userEmail) userData.em = [sha256(params.userEmail)];
   if (params.userPhone) {
-    const hashed = hashPhone(params.userPhone);
-    if (hashed) userData.ph = [hashed];
+    userData.ph = [hashPhone(params.userPhone)];
   }
   if (params.clientIp) userData.client_ip_address = params.clientIp;
   if (params.userAgent) userData.client_user_agent = params.userAgent;
@@ -55,10 +54,13 @@ export async function sendConversionsEvent(params: ConversionsEventParams): Prom
 
   try {
     const res = await fetch(
-      `https://graph.facebook.com/v19.0/${pixelId}/events?access_token=${token}`,
+      `https://graph.facebook.com/v19.0/${pixelId}/events`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
         body: JSON.stringify(payload),
       }
     );

--- a/lib/analytics/meta-pixel.ts
+++ b/lib/analytics/meta-pixel.ts
@@ -1,0 +1,73 @@
+// lib/analytics/meta-pixel.ts
+
+declare global {
+  interface Window {
+    fbq: (action: string, event: string, params?: Record<string, unknown>, options?: { eventID?: string }) => void;
+    _fbq: unknown;
+  }
+}
+
+function isLoaded(): boolean {
+  return typeof window !== 'undefined' && typeof window.fbq === 'function';
+}
+
+export function trackPageView(): void {
+  if (!isLoaded()) return;
+  window.fbq('track', 'PageView');
+}
+
+export function trackViewContent(params: { id: string; name: string; price: number }): void {
+  if (!isLoaded()) return;
+  window.fbq('track', 'ViewContent', {
+    content_ids: [params.id],
+    content_type: 'product',
+    content_name: params.name,
+    value: params.price,
+    currency: 'INR',
+  });
+}
+
+/** Returns the generated eventId for server-side deduplication. */
+export function trackAddToCart(params: { id: string; name: string; price: number }): string {
+  const eventId = crypto.randomUUID();
+  if (!isLoaded()) return eventId;
+  window.fbq('track', 'AddToCart', {
+    content_ids: [params.id],
+    content_type: 'product',
+    content_name: params.name,
+    value: params.price,
+    currency: 'INR',
+  }, { eventID: eventId });
+  return eventId;
+}
+
+/** Returns the generated eventId for server-side deduplication. */
+export function trackInitiateCheckout(params: { numItems: number; total: number }): string {
+  const eventId = crypto.randomUUID();
+  if (!isLoaded()) return eventId;
+  window.fbq('track', 'InitiateCheckout', {
+    num_items: params.numItems,
+    value: params.total,
+    currency: 'INR',
+  }, { eventID: eventId });
+  return eventId;
+}
+
+/** eventId must come from the server confirm response for deduplication. */
+export function trackPurchase(params: { orderId: string; total: number; itemIds: string[] }, eventId: string): void {
+  if (!isLoaded()) return;
+  window.fbq('track', 'Purchase', {
+    value: params.total,
+    currency: 'INR',
+    content_ids: params.itemIds,
+    content_type: 'product',
+    order_id: params.orderId,
+  }, { eventID: eventId });
+}
+
+export function trackSearch(params: { query: string }): void {
+  if (!isLoaded()) return;
+  window.fbq('track', 'Search', {
+    search_string: params.query,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds Facebook Pixel (ID `2325926804563073`) with full-funnel browser tracking: PageView, ViewContent, AddToCart, InitiateCheckout, Purchase, Search
- Adds Facebook Conversions API (server-side) for AddToCart, InitiateCheckout, and Purchase with SHA-256-hashed PII for iOS 14+ accuracy
- Browser and server events share a UUID `event_id` so Facebook deduplicates them automatically

## Architecture

| File | Role |
|------|------|
| `lib/analytics/meta-pixel.ts` | Typed `fbq()` wrappers; generates UUIDs for deduplication |
| `lib/analytics/conversions-api.ts` | Server-side Graph API client; SHA-256 PII hashing; Bearer auth |
| `components/MetaPixelScript.tsx` | Injects pixel script; fires PageView on SPA route changes |
| `app/api/analytics/events/route.ts` | Receives AddToCart/InitiateCheckout from client; reads PII server-side from Supabase session |
| `app/api/payments/confirm/route.ts` | Fires Purchase server event; returns `pixel_event_id` |
| `app/payment/[orderId]/page.tsx` | Fires browser Purchase pixel using server-returned `event_id` |

## Safety

- PII (email, phone) is **never** sent in client request bodies — always read server-side from Supabase session
- `FACEBOOK_CONVERSIONS_API_TOKEN` sent via `Authorization: Bearer` header (not query string)
- All analytics calls are fire-and-forget — they cannot throw or block cart/checkout/payment flows
- `pixelId` validated against `/^\d+$/` before interpolation into inline script
- `eventName` allowlist on `/api/analytics/events`

## Required env vars

```
NEXT_PUBLIC_META_PIXEL_ID=2325926804563073
FACEBOOK_CONVERSIONS_API_TOKEN=<from Events Manager → Settings → Generate Access Token>
```

## Test plan

- [ ] Replace token placeholder with real token in production env (Vercel)
- [ ] Verify each event fires using Meta Pixel Helper Chrome extension: PageView, ViewContent, AddToCart, InitiateCheckout, Purchase, Search
- [ ] In Events Manager → Test Events, confirm browser + server events show "1 matched" (deduplication) for AddToCart / InitiateCheckout / Purchase
- [ ] Verify cart/checkout/payment flows still work end-to-end (analytics must never block them)
- [ ] Verify component renders nothing when `NEXT_PUBLIC_META_PIXEL_ID` is missing